### PR TITLE
Import instead of fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ back-end code execution uses [Binder](https://mybinder.org) 💖
 
 ## ✅ Quickstart
 
-1. Fork this repo, install it and make sure the app is running locally.
+1. [Import](https://github.com/new/import) this repo, install it and make sure the app is running locally.
 2. Customize the [`meta.json`](meta.json) and
    [`binder/requirements.txt`](binder/requirements.txt).
 3. Build a [Binder](https://mybinder.org) from the `binder` branch of this repo.


### PR DESCRIPTION
Amazing work! You might want to recommend that people import the repo for their own use, rather than fork it. The reason for this is that if someone wants to create more than one course out of this, they will need to create multiple forks of the repo, which is not currently possible. 
